### PR TITLE
remove rails 5 restriction

### DIFF
--- a/validates_serialized.gemspec
+++ b/validates_serialized.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activemodel", ">= 3.0", "< 5.0"
+  spec.add_dependency "activemodel", ">= 3.0"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "sqlite3", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.1"


### PR DESCRIPTION
I ran the tests against `ActiveModel` version `5.0.0` and they all passed. Is there a reason Rails 5 support is restricted?

Let me know if you want to upgrade `Gemfile.lock` to use `5.0.0`.
