### PR TITLE
Allow hash with stringified keys to validate

### DIFF
--- a/lib/validates_serialized/validateable_hash.rb
+++ b/lib/validates_serialized/validateable_hash.rb
@@ -12,8 +12,10 @@ class ValidateableHash < ValidateableObject
 
   private
   def method_missing(method, *args, &block)
-    if @object.keys.include?(method)
+    if @object.key?(method)
       @object[method]
+    elsif @object.key?(method.to_s)
+      @object[method.to_s]
     else
       super
     end

--- a/spec/validateable_hash_spec.rb
+++ b/spec/validateable_hash_spec.rb
@@ -33,6 +33,12 @@ describe ValidateableHash do
     it "does not raises error for non-existent methods" do
       expect { subject.arglebargle }.not_to raise_error
     end
+    context "foo" do
+      let!(:hash) { {"key_1" => "boy"} }
+      it "defines key_1 attribute" do
+        subject.key_1.should eq("boy")
+      end
+    end
   end
 
   describe "validation block" do


### PR DESCRIPTION
- When using this with libraries such as active interaction,
  the hash that is get's validated has keys which are strings.
  This commit allows the same behaviour as keys which are symbols
