### PR TITLE
Allow the use of the :if argument to call local methods

### DIFF
--- a/lib/validates_serialized/validateable_object.rb
+++ b/lib/validates_serialized/validateable_object.rb
@@ -3,8 +3,21 @@ require 'active_model'
 class ValidateableObject
   include ::ActiveModel::Validations
 
-  def initialize(object)
+  attr_reader :record
+  def initialize(record, object)
     @object = object
+    @record = record
+  end
+
+  def self.validates(method, *args, &block)
+    if args.first[:if].is_a?(Symbol)
+      args.first[:if] = proc do |if_method|
+        proc do |serialized_object|
+          serialized_object.record.send(if_method)
+        end
+      end.call(args.first[:if])
+    end
+    super
   end
 
   def self.method_missing(method, *args, &block)

--- a/lib/validates_serialized/validators/array_block_validator.rb
+++ b/lib/validates_serialized/validators/array_block_validator.rb
@@ -9,11 +9,11 @@ module ActiveModel
       private
       def validate_each(record, attribute, array)
         raise TypeError, "#{attribute} is not an Array" unless array.is_a?(Array)
-        errors = get_serialized_object_errors(array)
+        errors = get_serialized_object_errors(record, array)
         add_errors_to_record(record, attribute, errors)
       end
 
-      def build_serialized_object(value)
+      def build_serialized_object(record, value)
         #TODO: For the Rails 4 version, I can just clear_validators! on the ValidateableHash
         temp_class = Class.new(ValidateableArrayValue)
         temp_class_name = "ValidateableArrayValue_#{SecureRandom.hex}"
@@ -21,13 +21,13 @@ module ActiveModel
           self.class.send(:remove_const, temp_class_name)
         end
         self.class.const_set(temp_class_name, temp_class)
-        temp_class.new(value)
+        temp_class.new(record, value)
       end
 
-      def get_serialized_object_errors(array)
+      def get_serialized_object_errors(record, array)
         messages = []
         array.each do |value|
-          serialized_object = build_serialized_object(value)
+          serialized_object = build_serialized_object(record, value)
           serialized_object.class_eval &@block
           serialized_object.valid?
           message = serialized_object.errors.messages[:value]

--- a/lib/validates_serialized/validators/hash_block_validator.rb
+++ b/lib/validates_serialized/validators/hash_block_validator.rb
@@ -9,18 +9,40 @@ module ActiveModel
       private
       def validate_each(record, attribute, value)
         raise TypeError, "#{attribute} is not a Hash" unless value.is_a?(Hash)
-        error_hash = get_serialized_object_errors(value)
+        error_hash = get_serialized_object_errors(record, value)
         add_errors_to_record(record, attribute, error_hash)
         ValidateableHash.clear_validators!
       end
 
-      def build_serialized_object(value)
+      def build_serialized_object(record, value)
         ValidateableHash.clear_validators!
-        ValidateableHash.new(value)
+        ValidateableHash.new(record, value)
       end
 
-      def get_serialized_object_errors(value)
-        serialized_object = build_serialized_object(value)
+
+      def get_serialized_object_errors(record, value)
+        serialized_object = build_serialized_object(record, value)
+
+        #test_method = Proc.new do |record2, &block|
+        #  @record3 = record2
+        #  def self.validates(method, *args, &block)
+        #    raise "bla" unless @record3.key?(method) || @record3.key?(method.to_s)
+        #  end
+        #  instance_eval(&block)
+        #end
+        #test_method.call(value, &@block)
+ 
+        #test_method = Proc.new do |record2, &block|
+        #  @keys = []
+        #  def self.validates(method, *args, &block)
+        #    @keys << method
+        #  end
+        #  instance_eval(&block)
+        #  @keys
+        #end
+        #binding.pry
+        #test_method.call(value, &@block)
+
         serialized_object.class_eval &@block
         serialized_object.valid?
         serialized_object.errors.messages

--- a/lib/validates_serialized/validators/hash_block_validator.rb
+++ b/lib/validates_serialized/validators/hash_block_validator.rb
@@ -22,27 +22,6 @@ module ActiveModel
 
       def get_serialized_object_errors(record, value)
         serialized_object = build_serialized_object(record, value)
-
-        #test_method = Proc.new do |record2, &block|
-        #  @record3 = record2
-        #  def self.validates(method, *args, &block)
-        #    raise "bla" unless @record3.key?(method) || @record3.key?(method.to_s)
-        #  end
-        #  instance_eval(&block)
-        #end
-        #test_method.call(value, &@block)
- 
-        #test_method = Proc.new do |record2, &block|
-        #  @keys = []
-        #  def self.validates(method, *args, &block)
-        #    @keys << method
-        #  end
-        #  instance_eval(&block)
-        #  @keys
-        #end
-        #binding.pry
-        #test_method.call(value, &@block)
-
         serialized_object.class_eval &@block
         serialized_object.valid?
         serialized_object.errors.messages

--- a/lib/validates_serialized/validators/object_block_validator.rb
+++ b/lib/validates_serialized/validators/object_block_validator.rb
@@ -9,18 +9,18 @@ module ActiveModel
 
       private
       def validate_each(record, attribute, value)
-        error_hash = get_serialized_object_errors(value)
+        error_hash = get_serialized_object_errors(record, value)
         add_errors_to_record(record, attribute, error_hash)
         ValidateableObject.clear_validators!
       end
 
-      def build_serialized_object(value)
+      def build_serialized_object(record, value)
         ValidateableObject.clear_validators!
-        ValidateableObject.new(value)
+        ValidateableObject.new(record, value)
       end
 
-      def get_serialized_object_errors(value)
-        serialized_object = build_serialized_object(value)
+      def get_serialized_object_errors(record, value)
+        serialized_object = build_serialized_object(record, value)
         serialized_object.class_eval &@block
         serialized_object.valid?
         serialized_object.errors.messages

--- a/spec/validateable_array_value_spec.rb
+++ b/spec/validateable_array_value_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe ValidateableArrayValue do
   let!(:array) { [1, 2, 3] }
   let!(:value) { array.first }
+  let!(:record) { double }
 
-  subject { described_class.new(value) }
+  subject { described_class.new(record, value) }
 
   it "responds to valid?" do
     subject.should be_valid

--- a/spec/validateable_hash_spec.rb
+++ b/spec/validateable_hash_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe ValidateableHash do
   let!(:hash) { { key_1: "boy", key_2: "girl" } }
+  let!(:record) { double }
 
-  subject { described_class.new(hash) }
+  subject { described_class.new(record, hash) }
 
   it "responds to valid?" do
     subject.should be_valid

--- a/spec/validateable_object_spec.rb
+++ b/spec/validateable_object_spec.rb
@@ -24,8 +24,9 @@ describe ValidateableObject do
   end
 
   let!(:object) { TestPerson.new(age: 26, name: "Thomas") }
+  let!(:record) { double }
 
-  subject { described_class.new(object) }
+  subject { described_class.new(record, object) }
 
   it "responds to valid?" do
     subject.should be_valid
@@ -61,7 +62,6 @@ describe ValidateableObject do
       end
       subject.should be_valid
     end
-
     it "handles errors when invalid" do
       subject.class_eval do
         validates :name, inclusion: { in: [ 'a', 'b', 'c' ] }
@@ -75,6 +75,26 @@ describe ValidateableObject do
         validates :other_property, inclusion: { in: [ 'a', 'b', 'c' ] }
       end
       expect { subject.valid? }.not_to raise_error
+    end
+
+    context "when if: :method is supplied" do
+      let!(:object) { TestPerson.new(age: 26) }
+      let!(:record) { double(if_method: true) }
+
+      it "validates false when if_method returns true and validation fails" do
+        subject.class_eval do
+          validates :name, presence: true, if: :if_method
+        end
+        subject.should_not be_valid
+      end
+
+      it "validates true when if_method returns false and validation fails" do
+        expect(record).to receive(:if_method).and_return(false)
+        subject.class_eval do
+          validates :name, presence: true, if: :if_method
+        end
+        subject.should be_valid
+      end
     end
   end
 end


### PR DESCRIPTION
Previous to this commit the following would fail silently:

```
validates_hash_keys :hash do
  validates :key, presence: true, if: :if_method
end

def if_method
  false
end
```

This PR allows us to call a locally scoped method only for the if: argument.

If you are happy with this PR we should probably add documentation
