### PR TITLE
Define `record` to let ValidateableObject access the outer model

### DIFF
--- a/lib/validates_serialized/validateable_object.rb
+++ b/lib/validates_serialized/validateable_object.rb
@@ -2,9 +2,12 @@ require 'active_model'
 
 class ValidateableObject
   include ::ActiveModel::Validations
+  attr_reader :record
 
-  def initialize(object)
+  def initialize(object, record)
     @object = object
+    @record = record
+    @record = @record.record while @record.is_a? ValidateableObject
   end
 
   def self.method_missing(method, *args, &block)

--- a/lib/validates_serialized/validators/array_block_validator.rb
+++ b/lib/validates_serialized/validators/array_block_validator.rb
@@ -9,11 +9,11 @@ module ActiveModel
       private
       def validate_each(record, attribute, array)
         raise TypeError, "#{attribute} is not an Array" unless array.is_a?(Array)
-        errors = get_serialized_object_errors(array)
+        errors = get_serialized_object_errors(array, record)
         add_errors_to_record(record, attribute, errors)
       end
 
-      def build_serialized_object(value)
+      def build_serialized_object(value, record)
         #TODO: For the Rails 4 version, I can just clear_validators! on the ValidateableHash
         temp_class = Class.new(ValidateableArrayValue)
         temp_class_name = "ValidateableArrayValue_#{SecureRandom.hex}"
@@ -21,13 +21,13 @@ module ActiveModel
           self.class.send(:remove_const, temp_class_name)
         end
         self.class.const_set(temp_class_name, temp_class)
-        temp_class.new(value)
+        temp_class.new(value, record)
       end
 
-      def get_serialized_object_errors(array)
+      def get_serialized_object_errors(array, record)
         messages = []
         array.each do |value|
-          serialized_object = build_serialized_object(value)
+          serialized_object = build_serialized_object(value, record)
           serialized_object.class_eval &@block
           serialized_object.valid?
           message = serialized_object.errors.messages[:value]

--- a/lib/validates_serialized/validators/hash_block_validator.rb
+++ b/lib/validates_serialized/validators/hash_block_validator.rb
@@ -9,18 +9,18 @@ module ActiveModel
       private
       def validate_each(record, attribute, value)
         raise TypeError, "#{attribute} is not a Hash" unless value.is_a?(Hash)
-        error_hash = get_serialized_object_errors(value)
+        error_hash = get_serialized_object_errors(value, record)
         add_errors_to_record(record, attribute, error_hash)
         ValidateableHash.clear_validators!
       end
 
-      def build_serialized_object(value)
+      def build_serialized_object(value, record)
         ValidateableHash.clear_validators!
-        ValidateableHash.new(value)
+        ValidateableHash.new(value, record)
       end
 
-      def get_serialized_object_errors(value)
-        serialized_object = build_serialized_object(value)
+      def get_serialized_object_errors(value, record)
+        serialized_object = build_serialized_object(value, record)
         serialized_object.class_eval &@block
         serialized_object.valid?
         serialized_object.errors.messages

--- a/lib/validates_serialized/validators/object_block_validator.rb
+++ b/lib/validates_serialized/validators/object_block_validator.rb
@@ -9,18 +9,18 @@ module ActiveModel
 
       private
       def validate_each(record, attribute, value)
-        error_hash = get_serialized_object_errors(value)
+        error_hash = get_serialized_object_errors(value, record)
         add_errors_to_record(record, attribute, error_hash)
         ValidateableObject.clear_validators!
       end
 
-      def build_serialized_object(value)
+      def build_serialized_object(value, record)
         ValidateableObject.clear_validators!
-        ValidateableObject.new(value)
+        ValidateableObject.new(value, record)
       end
 
-      def get_serialized_object_errors(value)
-        serialized_object = build_serialized_object(value)
+      def get_serialized_object_errors(value, record)
+        serialized_object = build_serialized_object(value, record)
         serialized_object.class_eval &@block
         serialized_object.valid?
         serialized_object.errors.messages


### PR DESCRIPTION
I encountered a situation where I needed to give a validation on a serialized Hash access to the outer, "real" object - for instance, validations conditional on some state of the outer object (although there are other applications - I personally have a custom validation that has to check a complex predicate which may depend on state of the outer object).

This change defined `@record` as a readable member on `ValidateableObject`, which is the inner object passed to `if:` predicates. `record` will point to the outer `AR::Base` object through arbitrary levels of nesting (array in hash, hash in array etc).